### PR TITLE
Launch a container in the detached mode and launch it with preferred name

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ cd grafana-aio
 docker build -t grafana-aio .
 
 docker run \
+    -d \
+    --name grafana-aio \
     -p 3000:3000 \
     -p 9090:9090 \
     -p 9200:9200 \
@@ -76,6 +78,8 @@ docker run \
 
 ```bash
 docker run \
+    -d \
+    --name grafana-aio \
     -p 3000:3000 \
     -p 9090:9090 \
     -p 9200:9200 \


### PR DESCRIPTION
### Highlights of the PR
1. Name the container using `--name`

- It gives us the flexibility of naming the container with the preferred name and avoids the activity of finding the container name that was generated automatically by the system among the long list of various random containers. 

2. Launch the container in the detached mode using `-d`

- It gives us the flexibility of launching/executing `entrypoint` scripts in the background. Otherwise `run`command executes the entrypoint script as init and hangs there leaving an impression that launching is in progress.
